### PR TITLE
SBOM file names

### DIFF
--- a/gui/src/app/features/comparison/comparison-page/comparison-page.component.ts
+++ b/gui/src/app/features/comparison/comparison-page/comparison-page.component.ts
@@ -77,7 +77,7 @@ export class ComparisonPageComponent {
 
     for(let i = 0; i < keys.length; i++) {
       let key = keys[i];
-      let value = this.getSBOMAlias(key);
+      let value = this.getSBOMAlias(key) as string;
 
       data[key] = value;
     }

--- a/gui/src/app/shared/services/data-handler.service.ts
+++ b/gui/src/app/shared/services/data-handler.service.ts
@@ -68,7 +68,8 @@ export class DataHandlerService {
   }
 
   getSBOMAlias(path: string) {
-    return `SBOM ${path.split("\\").pop()}`;
+    const pathChar =  path.indexOf('/') !== -1 ? '/' : '\\';
+    return path.split(pathChar).pop();
   }
 
   async Compare(main: string, others: string[]): Promise<any> {
@@ -95,7 +96,7 @@ export class DataHandlerService {
           let keys = Object.keys(toSend);
 
           for(let i = 0; i < keys.length; i++) {
-              
+
             let path = keys[i];
 
               if(path === main) {
@@ -108,7 +109,7 @@ export class DataHandlerService {
           }
 
           this.lastSentFilePaths = filePaths;
-          
+
           this.client.post("compare", new HttpParams().set('contents', JSON.stringify(fileData)).set('fileNames', JSON.stringify(filePaths))).subscribe((result: any) => {
             this.comparison = result;
           })


### PR DESCRIPTION
Fixes getting file names for mac. This also removes the "SBOM" in front of the file names because it felt a bit superfluous; I can add it back if needed though.  I also added in returning the path as a string as that was causing errors on my end.