### PR TITLE
Determine translator based on file contents AND file extension

### DIFF
--- a/core/src/main/java/org/nvip/plugfest/tooling/translator/TranslatorPlugFest.java
+++ b/core/src/main/java/org/nvip/plugfest/tooling/translator/TranslatorPlugFest.java
@@ -32,7 +32,7 @@ public class TranslatorPlugFest {
         try {
             contents = new String(Files.readAllBytes(Paths.get(path)));
         } catch (Exception e) {
-            System.err.println("Error: " + e.getMessage());
+            System.err.println("Error: " + e.getMessage()); // TODO throw error
         }
 
         return translateContents(contents, path);
@@ -53,7 +53,7 @@ public class TranslatorPlugFest {
             TranslatorCore translator = getTranslator(contents, filePath);
 
             if (translator == null) System.err.println("Error translating file: " + filePath + ".\nReason: Invalid " +
-                    "SBOM file contents (could not assume schema).");
+                    "SBOM file contents (could not assume schema)."); // TODO throw error
             else sbom = translator.translateContents(contents, filePath);
         }
         catch (Exception e) {
@@ -66,7 +66,7 @@ public class TranslatorPlugFest {
     private static TranslatorCore getTranslator(String contents, String filePath) {
         String ext = filePath.substring(filePath.lastIndexOf('.') + 1).trim().toLowerCase();
 
-        switch (ext.toLowerCase()) {
+        switch (ext.toLowerCase()) { // TODO possibly scan for an entire file header to ensure validity?
             case "json" -> {
                 if (contents.contains("\"bomFormat\": \"CycloneDX\"")) return new TranslatorCDXJSON();
 //                else if (contents.contains("\"SPDXID\" : \"SPDXRef-DOCUMENT\"")) return new TranslatorSPDXJSON();


### PR DESCRIPTION
This PR aims to resolve #90, where only the file extension is used to find the correct translator. We now use unique SBOM header keywords that are found across multiple versions of both CycloneDX and SPDX to achieve this.

- Template code has been put in place for SPDX JSON, XML, and YAML translators
- CycloneDX only supports JSON and XML, so the only SBOMs we need to use file contents to assume are JSON and XML SBOMs.