### PR TITLE
Overhaul TranslatorSPDX using Regex

### DIFF
--- a/core/src/main/java/org/nvip/plugfest/tooling/translator/TranslatorCDXJSON.java
+++ b/core/src/main/java/org/nvip/plugfest/tooling/translator/TranslatorCDXJSON.java
@@ -5,9 +5,7 @@ import org.cyclonedx.model.Dependency;
 import org.cyclonedx.model.Metadata;
 import org.cyclonedx.parsers.JsonParser;
 import org.nvip.plugfest.tooling.Debug;
-import org.nvip.plugfest.tooling.translator.TranslatorCore;
 import org.nvip.plugfest.tooling.sbom.Component;
-import org.nvip.plugfest.tooling.sbom.uids.PURL;
 import org.nvip.plugfest.tooling.sbom.SBOM;
 
 import java.util.*;
@@ -113,14 +111,14 @@ public class TranslatorCDXJSON extends TranslatorCore {
                 this.loadComponent(new_component);
 
                 // If a top component doesn't exist, make this new component the top component
-                this.product = product == null ? new_component : product;
+                this.topComponent = topComponent == null ? new_component : topComponent;
 
             }
 
         }
 
         // Add the top component to the sbom
-        if(this.sbom.getAllComponents().size() == 0) { this.sbom.addComponent(null, product); }
+        if(this.sbom.getAllComponents().size() == 0) { this.sbom.addComponent(null, topComponent); }
 
         // Create dependency collection
         //Map<String, List<String>> dependencies;
@@ -146,7 +144,7 @@ public class TranslatorCDXJSON extends TranslatorCore {
             Debug.log(Debug.LOG_TYPE.WARN, "Could not find dependencies from CycloneDX Object. " +
                     "Defaulting all components to point to head component. File: " + file_path);
             dependencies.put(
-                    this.product.getUniqueID(),
+                    this.topComponent.getUniqueID(),
                     components.values().stream().map(x->x.getUniqueID()).collect(Collectors.toCollection(ArrayList::new))
             );
         }
@@ -155,14 +153,14 @@ public class TranslatorCDXJSON extends TranslatorCore {
         // Otherwise, default the dependencyTree by adding all subcomponents as children to the top component
         if( dependencies != null ) {
             try {
-                this.dependencyBuilder(components, this.product, null);
+                this.dependencyBuilder(components, this.topComponent, null);
             } catch (Exception e) {
                 Debug.log(Debug.LOG_TYPE.WARN, "Error building dependency tree. Dependency tree may be incomplete " +
                         "for: " + file_path);
             }
         }
 
-        this.defaultDependencies(this.product);
+        this.defaultDependencies(this.topComponent);
 
         return this.sbom;
 

--- a/core/src/main/java/org/nvip/plugfest/tooling/translator/TranslatorCDXXML.java
+++ b/core/src/main/java/org/nvip/plugfest/tooling/translator/TranslatorCDXXML.java
@@ -2,7 +2,6 @@ package org.nvip.plugfest.tooling.translator;
 
 import org.nvip.plugfest.tooling.Debug;
 import org.nvip.plugfest.tooling.sbom.*;
-import org.nvip.plugfest.tooling.sbom.uids.PURL;
 import org.w3c.dom.*;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -241,7 +240,7 @@ public class TranslatorCDXXML extends TranslatorCore {
 
                     this.loadComponent(component);
 
-                    this.product = product == null ? component : product;
+                    this.topComponent = topComponent == null ? component : topComponent;
 
                 }
 
@@ -280,7 +279,7 @@ public class TranslatorCDXXML extends TranslatorCore {
             }
         } else {
             dependencies.put(
-                    this.product.getUniqueID(),
+                    this.topComponent.getUniqueID(),
                     components.values().stream().map(x->x.getUniqueID()).collect(Collectors.toCollection(ArrayList::new))
             );
         }
@@ -289,13 +288,13 @@ public class TranslatorCDXXML extends TranslatorCore {
         // Create the top level component
         // Build the dependency tree using dependencyBuilder
         try { // TODO should these errors be thrown?
-            dependencyBuilder(components, this.product,null);
+            dependencyBuilder(components, this.topComponent,null);
         } catch (Exception e) {
             Debug.log(Debug.LOG_TYPE.ERROR, "Error processing dependency tree.");
         }
 
         try {
-            defaultDependencies(this.product);
+            defaultDependencies(this.topComponent);
         } catch (Exception e) {
             Debug.log(Debug.LOG_TYPE.ERROR, "Something went wrong with defaulting dependencies. A dependency tree may" +
                     " not exist.");

--- a/core/src/main/java/org/nvip/plugfest/tooling/translator/TranslatorCore.java
+++ b/core/src/main/java/org/nvip/plugfest/tooling/translator/TranslatorCore.java
@@ -29,7 +29,7 @@ public abstract class TranslatorCore {
     protected SBOM sbom;
 
     // The top level component (what the SBOM is about)
-    protected Component product;
+    protected Component topComponent;
 
     // Top level SBOM data
     protected HashMap<String, String> bom_data;
@@ -94,8 +94,8 @@ public abstract class TranslatorCore {
 
         // If there is no top component (product) already, try to create it
         // Otherwise, make sure it's in the SBOM
-        if (product == null) {
-            product = new Component(
+        if (topComponent == null) {
+            topComponent = new Component(
                     product_data.get("name"),
                     product_data.get("publisher"),
                     product_data.get("version"),
@@ -103,7 +103,7 @@ public abstract class TranslatorCore {
             );
         }
 
-        sbom.addComponent(null, product);
+        sbom.addComponent(null, topComponent);
     }
 
     /**

--- a/core/src/main/java/org/nvip/plugfest/tooling/translator/TranslatorSPDX.java
+++ b/core/src/main/java/org/nvip/plugfest/tooling/translator/TranslatorSPDX.java
@@ -181,7 +181,7 @@ public class TranslatorSPDX extends TranslatorCore {
             product_data.put("id", bom_data.get("id"));
             defaultTopComponent(product_data.get("id"), packages);
         } else {
-            product = components.get(product_id);
+            topComponent = components.get(product_id);
         }
 
         // Create the new SBOM Object with top level data
@@ -190,13 +190,13 @@ public class TranslatorSPDX extends TranslatorCore {
         // Create the top level component
         // Build the dependency tree using dependencyBuilder
         try {
-            this.dependencyBuilder(components, this.product, null);
+            this.dependencyBuilder(components, this.topComponent, null);
         } catch (Exception e) {
             Debug.log(Debug.LOG_TYPE.ERROR, "Error processing dependency tree.");
             Debug.log(Debug.LOG_TYPE.EXCEPTION, e.getMessage());
         }
 
-        this.defaultDependencies(this.product);
+        this.defaultDependencies(this.topComponent);
 
         // Return the final SBOM object
         return sbom;


### PR DESCRIPTION
`TranslatorSPDX` now translates a tag-value file by separating it into order-independent "blocks" of data (i.e. Unpackaged Files or Packages). It then uses regex patterns to break each line down into its tag-value components and further analyzes it.

Other notes:
- Decreased the amount of nested loops
- Separated each "block" parser/builder into its own method to make code easier to read.