### PR TITLE
fix black font on black background

### DIFF
--- a/gui/src/app/features/metrics/metrics-body/metrics-body.component.css
+++ b/gui/src/app/features/metrics/metrics-body/metrics-body.component.css
@@ -50,6 +50,7 @@
 
 .text {
   height: 100%;
+  color: white;
 }
 
 app-button {


### PR DESCRIPTION
Before "no sboms available" was black on a black background. 
<img width="1117" alt="Screenshot 2023-06-07 at 10 36 37 AM" src="https://github.com/SoftwareDesignLab/plugfest-tooling/assets/56976587/8473bc22-be08-4e8c-a7e9-5999b6d751f9">
