### PR TITLE
Dev registered processor speed fixes

### DIFF
--- a/core/src/main/java/org/nvip/plugfest/tooling/qa/tests/IsRegisteredTest.java
+++ b/core/src/main/java/org/nvip/plugfest/tooling/qa/tests/IsRegisteredTest.java
@@ -118,15 +118,35 @@ public class IsRegisteredTest extends MetricTest{
                         case "cran" -> response = extractFromCran(p);
                         case "pub" -> response = extractFromPub(p);
                         case "conda" -> response = extractFromConda(p);
-                        // a package manager that is not currently supported
-                        default -> {
+
+                        // package managers that are not supported yet
+                        case "alpm", "apk", "bitbucket", "deb",
+                                "docker", "generic", "github", "mlflow",
+                                "qpkg", "oci", "rpm", "swid", "swift"
+                                -> {
                             r = new Result(TEST_NAME, Result.STATUS.ERROR,
-                                    "Package Manager is currently not " +
-                                            "supported: " +
+                                    "Package Manager is a valid type but " +
+                                            "is currently not supported: " +
                                             packageManager);
                             r.addContext(c, "PURL Package Validation");
                             r.updateInfo(Result.Context.FIELD_NAME,
-                                    "PURL");
+                                    "PURL Package Manager");
+                            r.updateInfo(Result.Context.STRING_VALUE,
+                                    packageManager);
+                            purlResults.add(r);
+                            // error number to skip other results
+                            response = -1;
+                        }
+
+
+                        // a package manager that is not currently supported
+                        default -> {
+                            r = new Result(TEST_NAME, Result.STATUS.FAIL,
+                                    "Package Manager is an invalid type: " +
+                                            packageManager);
+                            r.addContext(c, "PURL Package Validation");
+                            r.updateInfo(Result.Context.FIELD_NAME,
+                                    "PURL Package Manager");
                             r.updateInfo(Result.Context.STRING_VALUE,
                                     p.toString());
                             purlResults.add(r);


### PR DESCRIPTION
Made sure connections were disconnected in `IsRegisteredTest` to try and increase the speeds of the test.
I also updated the default message to "Package Manager is currently not supported" instead of "Package manager is not recognized or unknown" (more need to be added for support).
HttpURLConnections were changed to HttpsURLConnection, since every url is https.

This does not completely fix the speed issue with `IsRegisteredTest`. The test varies based on package manager. It also seems to be dependent on the user's connection and how many packages have purls