### PR TITLE
User Friendly titles for Metrics

### DIFF
--- a/gui/src/app/features/comparison/comparison/comparison.component.html
+++ b/gui/src/app/features/comparison/comparison/comparison.component.html
@@ -40,7 +40,7 @@
         *ngFor="let conflict of getMetadataConflicts(getPathIndex(0))"
       >
         <div title class="title">
-          <span> {{ conflict.type }}</span>
+          <span style="text-transform: capitalize;"> {{ conflict.type.replaceAll("_", " ").toLowerCase() }}</span>
         </div>
         <div body>
           <span>{{"Target: " + conflict.target}}</span>
@@ -66,7 +66,7 @@
       *ngFor="let conflict of ComponentFilter(getComponentConflicts(getPathIndex(0)))[path[2]]"
     >
       <div title class="title">
-        <span> {{ conflict.type }}</span>
+        <span style="text-transform: capitalize;"> {{ conflict.type.replaceAll("_", " ").toLowerCase() }}</span>
       </div>
       <div body>
         <span>{{"Target: " + conflict.target}}</span>


### PR DESCRIPTION
- Titles are no longer enums (Uppercase with _ )

Before:
![image](https://github.com/SoftwareDesignLab/plugfest-tooling/assets/91503444/6a3e0395-d4e9-444c-9d1a-b4ad670d2410)

After: 
![image](https://github.com/SoftwareDesignLab/plugfest-tooling/assets/91503444/2fb93b0a-1613-44bb-845d-bbf90fdd3e33)
