### PR TITLE
Dev registered processor speed fixes

### DIFF
--- a/core/src/main/java/org/nvip/plugfest/tooling/qa/tests/IsRegisteredTest.java
+++ b/core/src/main/java/org/nvip/plugfest/tooling/qa/tests/IsRegisteredTest.java
@@ -227,7 +227,6 @@ public class IsRegisteredTest extends MetricTest{
                 p.getName().toLowerCase() +
                 "/" + p.getVersion());
         HttpsURLConnection huc = (HttpsURLConnection) url.openConnection();
-        huc.setRequestMethod("HEAD");
         huc.connect();
         // get the response code from this url
         int responseCode = huc.getResponseCode();
@@ -248,7 +247,6 @@ public class IsRegisteredTest extends MetricTest{
                 p.getName().toLowerCase() +
                 (p.getVersion() != null ? "/" + p.getVersion() : ""));
         HttpsURLConnection huc = (HttpsURLConnection) url.openConnection();
-        huc.setRequestMethod("HEAD");
         huc.connect();
         // get the response code from this url
         int responseCode = huc.getResponseCode();
@@ -271,7 +269,6 @@ public class IsRegisteredTest extends MetricTest{
                 p.getName().toLowerCase() +
                 (p.getVersion() != null ? "/" + p.getVersion() : ""));
         HttpsURLConnection huc = (HttpsURLConnection) url.openConnection();
-        huc.setRequestMethod("HEAD");
         huc.connect();
         // get the response code from this url
         int responseCode = huc.getResponseCode();
@@ -294,7 +291,6 @@ public class IsRegisteredTest extends MetricTest{
                 p.getName().toLowerCase() +
                 (p.getVersion() != null ? "/" + p.getVersion() : ""));
         HttpsURLConnection huc = (HttpsURLConnection) url.openConnection();
-        huc.setRequestMethod("HEAD");
         huc.connect();
         // get the response code from this url
         int responseCode = huc.getResponseCode();
@@ -320,7 +316,6 @@ public class IsRegisteredTest extends MetricTest{
                 p.getName().toLowerCase() + "@" +
                 p.getVersion());
         HttpsURLConnection huc = (HttpsURLConnection) url.openConnection();
-        huc.setRequestMethod("HEAD");
         huc.connect();
         // get the response code from this url
         int responseCode = huc.getResponseCode();
@@ -343,7 +338,6 @@ public class IsRegisteredTest extends MetricTest{
                 p.getName().toLowerCase() +
                 (p.getVersion() != null ? "/" + p.getVersion() : ""));
         HttpsURLConnection huc = (HttpsURLConnection) url.openConnection();
-        huc.setRequestMethod("HEAD");
         huc.connect();
         // get the response code from this url
         int responseCode = huc.getResponseCode();
@@ -371,7 +365,6 @@ public class IsRegisteredTest extends MetricTest{
                 p.getName().toLowerCase() +
                 (p.getVersion() != null ? "#v" + p.getVersion() : ""));
         HttpsURLConnection huc = (HttpsURLConnection) url.openConnection();
-        huc.setRequestMethod("HEAD");
         huc.connect();
         // get the response code from this url
         int responseCode = huc.getResponseCode();
@@ -394,7 +387,6 @@ public class IsRegisteredTest extends MetricTest{
                 p.getName().toLowerCase() + "/" +
                 (p.getVersion() != null ? "versions/" + p.getVersion() : ""));
         HttpsURLConnection huc = (HttpsURLConnection) url.openConnection();
-        huc.setRequestMethod("HEAD");
         huc.connect();
         // get the response code from this url
         int responseCode = huc.getResponseCode();
@@ -417,7 +409,6 @@ public class IsRegisteredTest extends MetricTest{
                 p.getName().toLowerCase() + "/" +
                 (p.getVersion() != null ? "-" + p.getVersion() : ""));
         HttpsURLConnection huc = (HttpsURLConnection) url.openConnection();
-        huc.setRequestMethod("HEAD");
         huc.connect();
         // get the response code from this url
         int responseCode = huc.getResponseCode();
@@ -440,7 +431,6 @@ public class IsRegisteredTest extends MetricTest{
                 p.getName().toLowerCase() + "/" +
                 (p.getVersion() != null ? "/" + p.getVersion() : ""));
         HttpsURLConnection huc = (HttpsURLConnection) url.openConnection();
-        huc.setRequestMethod("HEAD");
         huc.connect();
         // get the response code from this url
         int responseCode = huc.getResponseCode();
@@ -465,7 +455,6 @@ public class IsRegisteredTest extends MetricTest{
                 p.getName().toLowerCase() +
                 (p.getVersion() != null ? "?version=" + p.getVersion() : ""));
         HttpsURLConnection huc = (HttpsURLConnection) url.openConnection();
-        huc.setRequestMethod("HEAD");
         huc.connect();
         // get the response code from this url
         int responseCode = huc.getResponseCode();
@@ -493,7 +482,6 @@ public class IsRegisteredTest extends MetricTest{
                 p.getName().toLowerCase() +
                 (p.getVersion() != null ? "?version=" + p.getVersion() : ""));
         HttpsURLConnection huc = (HttpsURLConnection) url.openConnection();
-        huc.setRequestMethod("HEAD");
         huc.connect();
         // get the response code from this url
         int responseCode = huc.getResponseCode();
@@ -539,7 +527,6 @@ public class IsRegisteredTest extends MetricTest{
                 p.getVersion() + "/" +
                 p.getName() + ".podspec.json") ;
         HttpsURLConnection huc = (HttpsURLConnection) url.openConnection();
-        huc.setRequestMethod("HEAD");
         huc.connect();
         // get the response code from this url
         int responseCode = huc.getResponseCode();
@@ -565,7 +552,6 @@ public class IsRegisteredTest extends MetricTest{
                 (p.getVersion() != null ? "?version=" + p.getVersion() : "") +
                 "/index.html");
         HttpsURLConnection huc = (HttpsURLConnection) url.openConnection();
-        huc.setRequestMethod("HEAD");
         huc.connect();
         // get the response code from this url
         int responseCode = huc.getResponseCode();
@@ -588,7 +574,6 @@ public class IsRegisteredTest extends MetricTest{
                 p.getName().toLowerCase() +
                 (p.getVersion() != null ? "/versions/" + p.getVersion() : ""));
         HttpsURLConnection huc = (HttpsURLConnection) url.openConnection();
-        huc.setRequestMethod("HEAD");
         huc.connect();
         // get the response code from this url
         int responseCode = huc.getResponseCode();
@@ -622,7 +607,6 @@ public class IsRegisteredTest extends MetricTest{
                 p.getName().toLowerCase() + "-" + p.getVersion() + "-" +
                 build + "." + type);
         HttpsURLConnection huc = (HttpsURLConnection) url.openConnection();
-        huc.setRequestMethod("HEAD");
         huc.connect();
         // get the response code from this url
         int responseCode = huc.getResponseCode();


### PR DESCRIPTION
Forgot to add docstrings into `checkResponseCode` method.

Initially set request method to "HEAD", but showed very little to no effect on speed, so just made sure HUC connects and disconnects
